### PR TITLE
Made tags setter be able to handle both String and Array + Mongoid 3 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmtags
 \#*
 .\#*
 *.swp
+.idea

--- a/lib/mongoid/taggable_with_context.rb
+++ b/lib/mongoid/taggable_with_context.rb
@@ -3,6 +3,8 @@ module Mongoid::TaggableWithContext
 
   class AggregationStrategyMissing < Exception; end
 
+  TAGGABLE_DEFAULT_SEPARATOR = ' '
+
   included do
     class_attribute :taggable_with_context_options
     class_attribute :context_array_to_context_hash
@@ -45,7 +47,7 @@ module Mongoid::TaggableWithContext
       options = args.extract_options!
       tags_field = (args.blank? ? :tags : args.shift).to_sym
       options.reverse_merge!(
-        :separator => ' ',
+        :separator => TAGGABLE_DEFAULT_SEPARATOR,
         :array_field => "#{tags_field}_array".to_sym
       )
       tags_array_field = options[:array_field]
@@ -129,7 +131,7 @@ module Mongoid::TaggableWithContext
     end
 
     def set_tag_separator_for(context, value)
-      self.taggable_with_context_options[context][:separator] = value.nil? ? " " : value.to_s
+      self.taggable_with_context_options[context][:separator] = value.nil? ? TAGGABLE_DEFAULT_SEPARATOR : value.to_s
     end
 
     # Find documents tagged with all tags passed as a parameter, given
@@ -151,11 +153,11 @@ module Mongoid::TaggableWithContext
 
     # Helper method to convert a String to an Array based on the
     # configured tag separator.
-    def convert_string_to_array(str = "", separator = " ")
+    def convert_string_to_array(str = "", separator = TAGGABLE_DEFAULT_SEPARATOR)
       clean_up_array(str.split(separator))
     end
 
-    def convert_array_to_string(ary = [], separator = " ")
+    def convert_array_to_string(ary = [], separator = TAGGABLE_DEFAULT_SEPARATOR)
       #ary.join(separator)
       (ary || []).join(separator)
     end

--- a/spec/mongoid_taggable_with_context_spec.rb
+++ b/spec/mongoid_taggable_with_context_spec.rb
@@ -95,7 +95,7 @@ describe Mongoid::TaggableWithContext do
     end
     
     it "should remove repeated tags from array" do
-      @m.tags_array = %w[some new tags some new tags]
+      @m.tags = %w[some new tags some new tags]
       @m.tags_array.should == %w[some new tags]
     end
     
@@ -106,6 +106,17 @@ describe Mongoid::TaggableWithContext do
 
     it "should remove empty strings from array" do
       @m.tags = ["some", "", "new", "", "tags"]
+      @m.tags_array.should == %w[some new tags]
+    end
+  end
+
+  context "saving tags from array using tags_array alias method" do
+    before :each do
+      @m = MyModel.new
+    end
+
+    it "should remove nil tags from array" do
+      @m.tags_array = ["some", nil, "new", nil, "tags"]
       @m.tags_array.should == %w[some new tags]
     end
   end

--- a/spec/mongoid_taggable_with_context_spec.rb
+++ b/spec/mongoid_taggable_with_context_spec.rb
@@ -79,12 +79,12 @@ describe Mongoid::TaggableWithContext do
     end
     
     it "should remove repeated tags from array" do
-      @m.tags_array = %w[some new tags some new tags]
+      @m.tags = %w[some new tags some new tags]
       @m.tags.should == "some new tags"
     end
     
     it "should remove nil tags from array" do
-      @m.tags_array = ["some", nil, "new", nil, "tags"]
+      @m.tags = ["some", nil, "new", nil, "tags"]
       @m.tags.should == "some new tags"
     end
   end
@@ -96,16 +96,16 @@ describe Mongoid::TaggableWithContext do
     
     it "should remove repeated tags from array" do
       @m.tags_array = %w[some new tags some new tags]
-      @m.tags_array == %w[some new tags]
+      @m.tags_array.should == %w[some new tags]
     end
     
     it "should remove nil tags from array" do
-      @m.tags_array = ["some", nil, "new", nil, "tags"]
+      @m.tags = ["some", nil, "new", nil, "tags"]
       @m.tags_array.should == %w[some new tags]
     end
 
     it "should remove empty strings from array" do
-      @m.tags_array = ["some", "", "new", "", "tags"]
+      @m.tags = ["some", "", "new", "", "tags"]
       @m.tags_array.should == %w[some new tags]
     end
   end


### PR DESCRIPTION
I've changed `tags=` method so it accepts a String or an Array. This in practice for Rails as often times you may have an array of checkboxes for example from which you want to set the field value.

This fork is based on the @lgs fork which is upgraded for Mongoid 3 support.
