### PR TITLE
Renegerated gemspec -- please re-release 1.1.1

### DIFF
--- a/mongoid_taggable_with_context.gemspec
+++ b/mongoid_taggable_with_context.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Qian", "Luca G. Soave", "John Shields", "Wilker Lucio", "Ches Martin"]
-  s.date = "2013-05-18"
+  s.date = "2013-05-26"
   s.description = "Add multiple tag fields on Mongoid documents with aggregation capability."
   s.extra_rdoc_files = [
     "LICENSE.txt",
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
     "lib/mongoid/taggable_with_context.rb",
     "lib/mongoid/taggable_with_context/aggregation_strategy/map_reduce.rb",
     "lib/mongoid/taggable_with_context/aggregation_strategy/real_time.rb",
+    "lib/mongoid/taggable_with_context/aggregation_strategy/real_time_group_by.rb",
     "lib/mongoid/taggable_with_context/deprecations.rb",
     "lib/mongoid/taggable_with_context/version.rb",
     "lib/mongoid_taggable_with_context.rb",
-    "mongoid_taggable_with_context.gemspec",
     "spec/mongoid_taggable_with_context_spec.rb",
     "spec/spec_helper.rb"
   ]
@@ -44,14 +44,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<mongoid>, [">= 3.0.0"])
-      s.add_development_dependency(%q<database_cleaner>, [">= 0"])
+      s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<yard>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
       s.add_dependency(%q<mongoid>, [">= 3.0.0"])
-      s.add_dependency(%q<database_cleaner>, [">= 0"])
+      s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<yard>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 1.0.0"])
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<mongoid>, [">= 3.0.0"])
-    s.add_dependency(%q<database_cleaner>, [">= 0"])
+    s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<yard>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 1.0.0"])


### PR DESCRIPTION
@lgs the gemspec that was released for v 1.1.1 is missing a required file (real_time_group_by.rb), and as result the official gem breaks when you try to use it with Rails.

I rebuilt the gemspec with `rake gemspec:generate`. Please deploy this (overwrite the existing 1.1.1 if possible since the existing deploy is broken.)
