### PR TITLE
Support all mongoid versions (2, 3, 4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,25 @@
 language: ruby
+
 bundler_args: --without development
+
 rvm:
+  - 1.9.2
   - 1.9.3
   - 2.0.0
+
 services:
   - mongodb
+
+env:
+  - MONGOID_VERSION=2
+  - MONGOID_VERSION=3
+  - MONGOID_VERSION=4
+
+matrix:
+  exclude:
+    - rvm: 1.9.2
+      env: MONGOID_VERSION=3
+    - rvm: 1.9.2
+      env: MONGOID_VERSION=4
+
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-bundler_args: --without development
-
 rvm:
   - 1.9.2
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - jruby-19mode # JRuby in 1.9 mode
+  - rbx-2
 
 services:
   - mongodb
@@ -18,6 +20,9 @@ matrix:
     - rvm: 1.9.2
       env: MONGOID_VERSION=3
     - rvm: 1.9.2
+      env: MONGOID_VERSION=4
+  allow_failures:
+    - rvm: rbx-2
       env: MONGOID_VERSION=4
 
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,14 @@
 source 'http://rubygems.org'
 
-gem 'mongoid', '>= 3.0.0'
+gemspec
 
-group :test, :development do
-  gem 'rake'
-  gem 'rspec'
-  gem 'yard'
-  gem 'bundler', '>= 1.0.0'
-  gem 'jeweler'
+case version = ENV['MONGOID_VERSION'] || "~> 3.1"
+  when /4/
+    gem "mongoid", :github => 'mongoid/mongoid'
+  when /3/
+    gem "mongoid", "~> 3.1"
+  when /2/
+    gem "mongoid", "~> 2.8"
+  else
+    gem "mongoid", version
 end
-

--- a/lib/mongoid/taggable_with_context.rb
+++ b/lib/mongoid/taggable_with_context.rb
@@ -185,7 +185,11 @@ module Mongoid::TaggableWithContext
     #
     # @since 1.1.1
     def mongoid_field_options(options = {})
-      options.slice(*::Mongoid::Fields::Validators::Macro::OPTIONS).merge!(type: Array)
+      if Mongoid::TaggableWithContext.mongoid2?
+        options.merge!(type: Array) # Skip validation for mongoid2
+      else
+        options.slice(*::Mongoid::Fields::Validators::Macro::OPTIONS).merge!(type: Array)
+      end
     end
 
     # Creates an index for the underlying Mongoid field.
@@ -194,7 +198,11 @@ module Mongoid::TaggableWithContext
     #
     # @since 1.1.1
     def create_taggable_mongoid_index(name)
-      index({ name => 1 }, { background: true })
+      if Mongoid::TaggableWithContext.mongoid2?
+        index :name, background: true
+      else
+        index({ name => 1 }, { background: true })
+      end
     end
 
     # Defines all accessor methods for the taggable context at both

--- a/lib/mongoid_taggable_with_context.rb
+++ b/lib/mongoid_taggable_with_context.rb
@@ -1,3 +1,42 @@
+module Mongoid::TaggableWithContext
+  def self.mongoid2?
+    ::Mongoid.const_defined? :Contexts
+  end
+  def self.mongoid3?
+    ::Mongoid.const_defined? :Observer
+  end
+end
+
+if Mongoid::TaggableWithContext.mongoid2?
+  module Mongoid
+    module Extensions
+      module Module
+
+        # Redefine the method. Will undef the method if it exists or simply
+        # just define it.
+        #
+        # @example Redefine the method.
+        #   Object.re_define_method("exists?") do
+        #     self
+        #   end
+        #
+        # @param [ String, Symbol ] name The name of the method.
+        # @param [ Proc ] block The method body.
+        #
+        # @return [ Method ] The new method.
+        #
+        # @since 3.0.0
+        def re_define_method(name, &block)
+          undef_method(name) if method_defined?(name)
+          define_method(name, &block)
+        end
+      end
+    end
+  end
+
+  ::Module.__send__(:include, Mongoid::Extensions::Module)
+end
+
 require 'active_support/concern'
 
 require File.join(File.dirname(__FILE__), 'mongoid/taggable_with_context')

--- a/mongoid_taggable_with_context.gemspec
+++ b/mongoid_taggable_with_context.gemspec
@@ -45,14 +45,14 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<mongoid>, [">= 3.0.0"])
+      s.add_runtime_dependency(%q<mongoid>)
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<yard>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
-      s.add_dependency(%q<mongoid>, [">= 3.0.0"])
+      s.add_dependency(%q<mongoid>)
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<yard>, [">= 0"])
@@ -60,7 +60,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<jeweler>, [">= 0"])
     end
   else
-    s.add_dependency(%q<mongoid>, [">= 3.0.0"])
+    s.add_dependency(%q<mongoid>)
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<yard>, [">= 0"])

--- a/spec/mongoid_taggable_with_context_spec.rb
+++ b/spec/mongoid_taggable_with_context_spec.rb
@@ -13,7 +13,8 @@ class M1
   include Mongoid::Document
   include Mongoid::TaggableWithContext
   include Mongoid::TaggableWithContext::AggregationStrategy::MapReduce
-  
+
+  field :user
   taggable
   taggable :a, as: :artists
 end
@@ -22,7 +23,8 @@ class M2
   include Mongoid::Document
   include Mongoid::TaggableWithContext
   include Mongoid::TaggableWithContext::AggregationStrategy::RealTime
-  
+
+  field :user
   taggable
   taggable :artists
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,5 +12,12 @@ RSpec.configure do |config|
 end
 
 Mongoid.configure do |config|
-  config.connect_to("mongoid_taggable_with_context_test")
+  if Mongoid::TaggableWithContext.mongoid2?
+    database = Mongo::Connection.new.db("mongoid_taggable_with_context_test")
+    database.add_user("mongoid", "test")
+    config.master = database
+    config.logger = nil
+  else
+    config.connect_to("mongoid_taggable_with_context_test")
+  end
 end


### PR DESCRIPTION
This pull request primarily adds back support for mongoid 2 and also fixes specs to pass with mongoid 4.   Travis test matrix was added in order to test mongoid 2, 3, and 4 against ruby 1.9.x, 2.0, jruby, and rubinius 2.  

All specs should be passing with the exception of mongoid 4 + rubinius 2 combo (which I'm allowing to fail in travis since mongoid 4 is still beta).
